### PR TITLE
fix:adapt how the patch is created to fit our need

### DIFF
--- a/bsdiffhs/format.py
+++ b/bsdiffhs/format.py
@@ -21,20 +21,30 @@ def write_patch(fo, len_dst, tcontrol, bdiff, bextra, window_sz2=DEFAULT_WINDOW_
     """write a BSDIFFHS-format patch to stream 'fo'
     """
     fo.write(MAGIC)
-    faux = BytesIO()
-    # write control tuples as series of offts
+    fo.write(core.encode_int64(len_dst))
+    
+    bdiff_offset = 0
+    bextra_offset = 0
+    
     for c in tcontrol:
-        for x in c:
-            faux.write(core.encode_int64(x))
-    # compress each block
-    bcontrol = heatshrink2.compress(faux.getvalue(), window_sz2, lookahead_sz2)
-    bdiff = heatshrink2.compress(bdiff, window_sz2, lookahead_sz2)
-    bextra = heatshrink2.compress(bextra, window_sz2, lookahead_sz2)
-    for n in len(bcontrol), len(bdiff), len_dst:
-        fo.write(core.encode_int64(n))
-    fo.write(bcontrol)
-    fo.write(bdiff)
-    fo.write(bextra)
+        # Convert control tuples to series of offts and then compress
+        control_data = b''.join([core.encode_int64(x) for x in c])
+        control_data_compressed = heatshrink2.compress(control_data, window_sz2, lookahead_sz2)
+        fo.write(control_data_compressed)
+        
+        # Extract and write the appropriate segment of bdiff
+        segment_diff = bdiff[bdiff_offset:bdiff_offset+c[0]]
+        segment_diff_compressed = heatshrink2.compress(segment_diff, window_sz2, lookahead_sz2)
+        fo.write(segment_diff_compressed)
+        bdiff_offset += c[0]
+        
+        # Extract and write the appropriate segment of bextra
+        segment_extra = bextra[bextra_offset:bextra_offset+c[1]]
+        if c[1] > 0:  # Only compress if there's data
+            segment_extra_compressed = heatshrink2.compress(segment_extra, window_sz2, lookahead_sz2)
+            fo.write(segment_extra_compressed)
+        bextra_offset += c[1]
+
 
 
 def read_patch(fi, header_only=False, window_sz2=DEFAULT_WINDOW_SZ2, lookahead_sz2=DEFAULT_LOOKAHEAD_SZ2):
@@ -43,21 +53,39 @@ def read_patch(fi, header_only=False, window_sz2=DEFAULT_WINDOW_SZ2, lookahead_s
     magic = fi.read(8)
     if magic[:7] != MAGIC[:7]:
         raise ValueError("incorrect magic bsdiffhs header")
-    # length headers
-    len_control = core.decode_int64(fi.read(8))
-    len_diff = core.decode_int64(fi.read(8))
-    len_dst = core.decode_int64(fi.read(8))
-    # read the control header
-    bcontrol = heatshrink2.decompress(fi.read(len_control), INPUT_BUFFER_SIZE, window_sz2, lookahead_sz2)
-    tcontrol = [(core.decode_int64(bcontrol[i:i + 8]),
-                 core.decode_int64(bcontrol[i + 8:i + 16]),
-                 core.decode_int64(bcontrol[i + 16:i + 24]))
-                for i in range(0, len(bcontrol), 24)]
-    if header_only:
-        return len_control, len_diff, len_dst, tcontrol
-    # read the diff and extra blocks
-    bdiff = heatshrink2.decompress(fi.read(len_diff), INPUT_BUFFER_SIZE, window_sz2, lookahead_sz2)
-    bextra = heatshrink2.decompress(fi.read(), INPUT_BUFFER_SIZE, window_sz2, lookahead_sz2)
+
+    len_dst = core.decode_int64(fi.read(8))  # Lecture de la taille du fichier cible
+
+    tcontrol = []
+    bdiff = b""
+    bextra = b""
+
+    # Lire jusqu'à ce qu'on atteigne la fin du stream
+    while True:
+        # Essayer de lire le tuple de contrôle
+        control_data = fi.read(24)
+        if len(control_data) < 24:
+            break
+        
+        control_tuple = (
+            core.decode_int64(control_data[0:8]),
+            core.decode_int64(control_data[8:16]),
+            core.decode_int64(control_data[16:24])
+        )
+
+        tcontrol.append(control_tuple)
+
+        # Lire et décompresser le segment de bdiff
+        segment_diff_compressed = fi.read(control_tuple[0])
+        segment_diff = heatshrink2.decompress(segment_diff_compressed, INPUT_BUFFER_SIZE, window_sz2, lookahead_sz2)
+        bdiff += segment_diff
+        
+        # Lire et décompresser le segment de bextra s'il y a des données
+        if control_tuple[1] > 0:
+            segment_extra_compressed = fi.read(control_tuple[1])
+            segment_extra = heatshrink2.decompress(segment_extra_compressed, INPUT_BUFFER_SIZE, window_sz2, lookahead_sz2)
+            bextra += segment_extra
+
     return len_dst, tcontrol, bdiff, bextra
 
 


### PR DESCRIPTION
Changed the patch to fit our patch structure : 
- 8 bytes for Magic "BSDIFFHS" (non-compressed)
- 8 bytes for the size of the target firmware (non-compressed)
- 24 bytes for control data : ctrl[0] = diff, ctrl[1] = extra, ctrl[2] = offset (24 bytes are compressed)
- ctrl[0] bytes (compressed)
- ctrl[1] bytes (compressed)
then do it again until all the data from the patch have been read
- 24 bytes for control datas : ctrl[0] = diff, ctrl[1] = extra, ctrl[2] = offset (compressed)
- ctrl[0] bytes (compressed)
- ctrl[1] bytes (compressed)
- ...