### PR TITLE
fix: pass hs configs to read_patch in file_patch

### DIFF
--- a/bsdiffhs/format.py
+++ b/bsdiffhs/format.py
@@ -158,4 +158,4 @@ def file_patch(src_path, dst_path, patch_path, window_sz2=DEFAULT_WINDOW_SZ2, lo
 
     with open(patch_path, 'rb') as fi:
         with open(dst_path, 'wb') as fo:
-            fo.write(core.patch(read_data(src_path), *read_patch(fi)))
+          fo.write(core.patch(read_data(src_path), *read_patch(fi, window_sz2=window_sz2, lookahead_sz2=lookahead_sz2)))


### PR DESCRIPTION
The goal of this merge request is to fix how we called read_patch in the function file_patch : the heatshrink configuration (window_sz2 and lookahead_sz2) were not passed as parameters to read_patch resulting in read_patch using the default heatshrink configuration even if we passed parameters to the file_patch function.