### PR TITLE
ci: upgrading cibuildwheel action to 2.17

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -20,7 +20,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.0
+        uses: pypa/cibuildwheel@v2.17.0
         # to supply options, put them in 'env', like:
         env:
           # configure cibuildwheel to build native archs ('auto'), and some


### PR DESCRIPTION
Fix Github action building wheels by upgrading to 2.17

Issue #9